### PR TITLE
Add Jest testing framework and BoardLogic tests

### DIFF
--- a/hiragana-match3-react/jest.config.js
+++ b/hiragana-match3-react/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src']
+};

--- a/hiragana-match3-react/package.json
+++ b/hiragana-match3-react/package.json
@@ -5,20 +5,24 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.4.0",
-    "vite": "^5.1.0",
     "@vitejs/plugin-react": "^4.0.2",
-    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.20",
+    "jest": "^29.7.0",
     "postcss": "^8.4.30",
-    "autoprefixer": "^10.4.20"
+    "tailwindcss": "^3.4.0",
+    "ts-jest": "^29.3.4",
+    "typescript": "^5.4.0",
+    "vite": "^5.1.0"
   }
 }

--- a/hiragana-match3-react/src/game/BoardLogic.test.ts
+++ b/hiragana-match3-react/src/game/BoardLogic.test.ts
@@ -1,0 +1,57 @@
+import { findWords, collapseAndRefill, randomTile } from './BoardLogic';
+import TrieNode from './Trie';
+import { Tile } from '../types';
+
+describe('findWords', () => {
+  let trie: TrieNode;
+  beforeEach(() => {
+    trie = new TrieNode();
+    trie.insert('あい');
+  });
+
+  test('detects horizontal words', () => {
+    const board: Tile[][] = [
+      [{ kana: 'あ', id: '1' }, { kana: 'い', id: '2' }],
+      [{ kana: 'え', id: '3' }, { kana: 'お', id: '4' }]
+    ];
+    const words = findWords(board, trie);
+    expect(words).toEqual([[
+      [0, 0], [0, 1]
+    ]]);
+  });
+
+  test('detects vertical words', () => {
+    const board: Tile[][] = [
+      [{ kana: 'あ', id: '1' }],
+      [{ kana: 'い', id: '2' }]
+    ];
+    const words = findWords(board, trie);
+    expect(words).toEqual([[
+      [0, 0], [1, 0]
+    ]]);
+  });
+});
+
+describe('collapseAndRefill', () => {
+  test('collapses cleared tiles and refills new ones', () => {
+    const board: Tile[][] = [
+      [{ kana: 'あ', id: '1' }],
+      [{ kana: 'い', id: '2' }],
+      [{ kana: 'う', id: '3' }]
+    ];
+    const cleared = [
+      [false],
+      [true],
+      [false]
+    ];
+    const newTile: Tile = { kana: 'か', id: 'new' };
+    jest.spyOn(require('./BoardLogic'), 'randomTile').mockReturnValueOnce(newTile);
+
+    const result = collapseAndRefill(board, cleared, ['か']);
+    expect(result).toEqual([
+      [newTile],
+      [{ kana: 'あ', id: '1' }],
+      [{ kana: 'う', id: '3' }]
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest preset
- add `npm test` script
- create initial tests for `findWords` and `collapseAndRefill`

## Testing
- `npm test --silent` *(fails: Cannot find module './BaseWatchPlugin')*

------
https://chatgpt.com/codex/tasks/task_e_6844275063f8832fa68426d9818e00da