### PR TITLE
Fix template literal escaping in Board and Tile components

### DIFF
--- a/hiragana-match3-react/src/components/Board.tsx
+++ b/hiragana-match3-react/src/components/Board.tsx
@@ -110,7 +110,7 @@ export default function Board({ rows, cols }: Props) {
     <div
       className="inline-grid"
       style={{
-        gridTemplateColumns: \`repeat(\${cols}, 3.25rem)\`
+        gridTemplateColumns: `repeat(${cols}, 3.25rem)`
       }}
     >
       {board.map((row, r) =>

--- a/hiragana-match3-react/src/components/Tile.tsx
+++ b/hiragana-match3-react/src/components/Tile.tsx
@@ -9,11 +9,11 @@ interface Props {
 
 export default function Tile({ tile, onClick, selected }: Props) {
   return (
-    <div
-      onClick={onClick}
-      className={\`tile w-12 h-12 m-0.5 bg-white hover:bg-yellow-100 transition
-        \${selected ? "ring-4 ring-blue-400" : ""}\`}
-    >
+      <div
+        onClick={onClick}
+        className={`tile w-12 h-12 m-0.5 bg-white hover:bg-yellow-100 transition
+          ${selected ? "ring-4 ring-blue-400" : ""}`}
+      >
       {tile.kana}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove escaped backticks in `Board.tsx` inline style
- fix template literal in `Tile.tsx`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68441fdafb2c832fa4274c795e0b93af