### PR TITLE
Add emoji support in popup

### DIFF
--- a/hiragana-match3-react/src/components/Board.tsx
+++ b/hiragana-match3-react/src/components/Board.tsx
@@ -1,4 +1,3 @@
-
 import { useEffect, useState } from "react";
 import Tile from "./Tile";
 import TrieNode from "../game/Trie";
@@ -10,7 +9,8 @@ import {
   hasLegalMove
 } from "../game/BoardLogic";
 import { kanaSetLevel1 } from "../data/kanaSets";
-import { words } from "../data/words";
+import { words, wordsMap, WordInfo } from "../data/words";
+import WordPopup from "./WordPopup";
 import { Tile as TileType } from "../types";
 
 interface Props {
@@ -26,6 +26,7 @@ interface Coord {
 export default function Board({ rows, cols }: Props) {
   const [board, setBoard] = useState<TileType[][]>([]);
   const [selected, setSelected] = useState<Coord | null>(null);
+  const [foundWord, setFoundWord] = useState<WordInfo | null>(null);
   const [trie] = useState<TrieNode>(() => {
     const t = new TrieNode();
     for (const w of words) t.insert(w);
@@ -65,6 +66,14 @@ export default function Board({ rows, cols }: Props) {
       // illegal swap, revert
       setSelected(null);
       return;
+    }
+
+    const matchedKana = matches
+      .map(group => group.map(([gr, gc]) => newBoard[gr][gc].kana).join(""))[0];
+    if (matchedKana && wordsMap[matchedKana]) {
+      setFoundWord(wordsMap[matchedKana]);
+    } else {
+      setFoundWord(null);
     }
 
     // Clear matches
@@ -107,22 +116,27 @@ export default function Board({ rows, cols }: Props) {
   };
 
   return (
-    <div
-      className="inline-grid"
-      style={{
-        gridTemplateColumns: \`repeat(\${cols}, 3.25rem)\`
-      }}
-    >
-      {board.map((row, r) =>
-        row.map((tile, c) => (
-          <Tile
-            key={tile.id}
-            tile={tile}
-            onClick={() => handleClick(r, c)}
-            selected={selected?.r === r && selected?.c === c}
-          />
-        ))
+    <>
+      {foundWord && (
+        <WordPopup info={foundWord} onClose={() => setFoundWord(null)} />
       )}
-    </div>
+      <div
+        className="inline-grid"
+        style={{
+          gridTemplateColumns: `repeat(${cols}, 3.25rem)`
+        }}
+      >
+        {board.map((row, r) =>
+          row.map((tile, c) => (
+            <Tile
+              key={tile.id}
+              tile={tile}
+              onClick={() => handleClick(r, c)}
+              selected={selected?.r === r && selected?.c === c}
+            />
+          ))
+        )}
+      </div>
+    </>
   );
 }

--- a/hiragana-match3-react/src/components/Tile.tsx
+++ b/hiragana-match3-react/src/components/Tile.tsx
@@ -11,8 +11,8 @@ export default function Tile({ tile, onClick, selected }: Props) {
   return (
     <div
       onClick={onClick}
-      className={\`tile w-12 h-12 m-0.5 bg-white hover:bg-yellow-100 transition
-        \${selected ? "ring-4 ring-blue-400" : ""}\`}
+      className={`tile w-12 h-12 m-0.5 bg-white hover:bg-yellow-100 transition
+        ${selected ? "ring-4 ring-blue-400" : ""}`}
     >
       {tile.kana}
     </div>

--- a/hiragana-match3-react/src/components/WordPopup.tsx
+++ b/hiragana-match3-react/src/components/WordPopup.tsx
@@ -1,0 +1,23 @@
+import { WordInfo } from "../data/words";
+
+interface Props {
+  info: WordInfo;
+  onClose: () => void;
+}
+
+export default function WordPopup({ info, onClose }: Props) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
+      <div className="bg-white p-4 rounded shadow-md text-center">
+        {info.emoji && <div className="text-4xl mb-1">{info.emoji}</div>}
+        <div className="text-2xl mb-2">
+          {info.kana}
+          {info.kanji && <span className="ml-2 text-xl text-gray-500">{info.kanji}</span>}
+        </div>
+        <div className="text-lg mb-1">{info.romaji}</div>
+        <div className="text-lg mb-3">{info.english}</div>
+        <button className="px-4 py-1 bg-blue-500 text-white rounded" onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}

--- a/hiragana-match3-react/src/data/words.ts
+++ b/hiragana-match3-react/src/data/words.ts
@@ -3,21 +3,36 @@
  * Very small word list for prototype/demo.
  * Replace with a larger JMdict-derived list for production.
  */
-export const words: string[] = [
-  "あい",   // love
-  "あお",   // blue
-  "さくら", // cherry blossom
-  "すし",
-  "ねこ",
-  "いぬ",
-  "かわ",
-  "やま",
-  "はな",
-  "ゆき",
-  "くも",
-  "あめ",
-  "もり",
-  "うみ",
-  "みみ",
-  "ほし"
+export interface WordInfo {
+  kana: string;
+  romaji: string;
+  english: string;
+  kanji?: string;
+  emoji?: string;
+}
+
+export const wordsInfo: WordInfo[] = [
+  { kana: "あい", romaji: "ai", english: "love", kanji: "愛", emoji: "❤️" },
+  { kana: "あお", romaji: "ao", english: "blue", kanji: "青", emoji: "🔵" },
+  { kana: "さくら", romaji: "sakura", english: "cherry blossom", kanji: "桜", emoji: "🌸" },
+  { kana: "すし", romaji: "sushi", english: "sushi", kanji: "寿司", emoji: "🍣" },
+  { kana: "ねこ", romaji: "neko", english: "cat", kanji: "猫", emoji: "🐱" },
+  { kana: "いぬ", romaji: "inu", english: "dog", kanji: "犬", emoji: "🐶" },
+  { kana: "かわ", romaji: "kawa", english: "river", kanji: "川", emoji: "🏞️" },
+  { kana: "やま", romaji: "yama", english: "mountain", kanji: "山", emoji: "⛰️" },
+  { kana: "はな", romaji: "hana", english: "flower", kanji: "花", emoji: "🌺" },
+  { kana: "ゆき", romaji: "yuki", english: "snow", kanji: "雪", emoji: "❄️" },
+  { kana: "くも", romaji: "kumo", english: "cloud", kanji: "雲", emoji: "☁️" },
+  { kana: "あめ", romaji: "ame", english: "rain", kanji: "雨", emoji: "🌧️" },
+  { kana: "もり", romaji: "mori", english: "forest", kanji: "森", emoji: "🌳" },
+  { kana: "うみ", romaji: "umi", english: "sea", kanji: "海", emoji: "🌊" },
+  { kana: "みみ", romaji: "mimi", english: "ear", kanji: "耳", emoji: "👂" },
+  { kana: "ほし", romaji: "hoshi", english: "star", kanji: "星", emoji: "⭐" },
+  { kana: "りんご", romaji: "ringo", english: "apple", kanji: "林檎", emoji: "🍎" }
 ];
+
+export const words: string[] = wordsInfo.map(w => w.kana);
+
+export const wordsMap: Record<string, WordInfo> = Object.fromEntries(
+  wordsInfo.map(w => [w.kana, w])
+);


### PR DESCRIPTION
## Summary
- extend `WordInfo` with optional `emoji`
- populate emoji for words and add ringo (apple)
- show emoji in `WordPopup`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684421b8f0ac832f9396f731595a4050